### PR TITLE
Remove Foundry Minimum Version badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # action-tracker
 A Foundry VTT module that adds action-tracking buttons to the token HUD and the combat tracker
 
-![Foundry Minimum Version](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/mfozz/action-tracker/main/module.json&label=Foundry%20Version&query=$.compatibility.minimum&colorB=orange)
+
 ![Latest Release](https://img.shields.io/github/v/release/mfozz/action-tracker)
 ![Downloads](https://img.shields.io/github/downloads/mfozz/action-tracker/total)
 [![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Frandom-loot-generator&colorB=4aa94a)](https://forge-vtt.com/bazaar#package=action-tracker)


### PR DESCRIPTION
Removed the Foundry Minimum Version badge from the README.